### PR TITLE
Bump example Chart from 0.3.0 to 0.4.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: 0.0.2-alpha.1
+appVersion: 0.0.2-alpha.2
 description: An example Chart.yaml
 name: example
 sources:
 - https://github.com/edaniszewski/charts-test.git
-version: 0.3.0
+version: 0.4.0


### PR DESCRIPTION
Bumps the example Helm Chart from 0.3.0 to 0.4.0.

The following files have also been updated:
- something.txt

---
*This PR was generated with [chart-releaser](https://github.com/edaniszewski/chart-releaser)*
