### PR TITLE
Bump helmv3-chart Chart from 0.1.0 to 0.2.0

### DIFF
--- a/helm3/Chart.yaml
+++ b/helm3/Chart.yaml
@@ -1,9 +1,7 @@
 apiVersion: v2
-name: helm3
+appVersion: v0.1.4
 description: A Helm chart for Kubernetes
-type: application
-version: 0.1.0
-appVersion: "0.1.0"
+name: helm3
 sources:
 - https://github.com/edaniszewski/charts-test.git
-
+version: 0.2.0

--- a/helm3/info.txt
+++ b/helm3/info.txt
@@ -1,1 +1,1 @@
-filler text
+filler stuff


### PR DESCRIPTION
Bumps the helmv3-chart Helm Chart from 0.1.0 to 0.2.0.

The following files have also been updated:
- helm3/info.txt

---
*This PR was generated with [chart-releaser](https://github.com/edaniszewski/chart-releaser)*
